### PR TITLE
Added sticky sessions, device type targeting, error codes, updated docs, small bug fixes

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:docs.joinmassive.com)"
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ClawPod
 
-Fetch web pages through residential proxy IPs via the Massive network. Geo-target by country, city, state, or zipcode. Single Python script, zero external dependencies — uses only the Python standard library.
+Fetch web pages through residential proxy IPs via the Massive network. Geo-target by country, city, state, or zipcode. Sticky sessions, device-type targeting, and exit node metadata. Single Python script, zero external dependencies — uses only the Python standard library.
 
 ---
 
@@ -53,6 +53,10 @@ No pip install needed — zero external dependencies.
 | `--city` | No | City name for geo-targeting (English) |
 | `--state` | No | State/subdivision code (e.g. `CA`, `TX`) |
 | `--zipcode` | No | Zipcode for geo-targeting |
+| `--session` | No | Sticky session ID (up to 255 chars) |
+| `--session-ttl` | No | Session TTL in minutes (1-240, default: 15) |
+| `--session-mode` | No | `strict` (default) or `flex` |
+| `--type` | No | Device type: `mobile`, `common`, or `tv` |
 
 ---
 
@@ -73,6 +77,15 @@ python3 scripts/fetch.py -u "https://httpbin.org/post" -m POST -d '{"key":"value
 
 # Fetch with zipcode targeting
 python3 scripts/fetch.py -u "https://example.com" --country US --zipcode 10001
+
+# Sticky session — reuse the same exit IP across requests
+python3 scripts/fetch.py -u "https://httpbin.org/ip" --session mysession1
+
+# Sticky session with custom TTL and flex error mode
+python3 scripts/fetch.py -u "https://httpbin.org/ip" --session mysession1 --session-ttl 30 --session-mode flex
+
+# Fetch through a mobile device IP
+python3 scripts/fetch.py -u "https://example.com" --type mobile --country US
 ```
 
 ---
@@ -90,9 +103,17 @@ python3 scripts/fetch.py -u "https://example.com" --country US --zipcode 10001
     "content-type": "application/json",
     "content-length": "32"
   },
-  "body": "{\n  \"origin\": \"73.162.45.89\"\n}"
+  "body": "{\n  \"origin\": \"73.162.45.89\"\n}",
+  "exit_node": {
+    "ip": "73.162.45.89",
+    "country": "US",
+    "timezone": "America/New_York",
+    "asn": "7922"
+  }
 }
 ```
+
+The `exit_node` field is included for HTTPS requests and contains metadata about the proxy exit node (IP, country, timezone, ASN). Use it to verify geo-targeting.
 
 ### Error
 
@@ -124,6 +145,43 @@ Geo-targeting flags are optional. They control which residential IP location to 
 | IP in London | `--country GB --city London` |
 | No geo preference | *(omit all geo flags)* |
 
+**Notes:**
+- `--country` is required when using any other geo flag
+- Geotargeting by country + city is more robust than by zipcode
+- If both `--state` and `--zipcode` are specified, `--city` is ignored
+- Overly narrow constraints may return a 503 — relax parameters if needed
+
+---
+
+## Sticky Sessions
+
+Use sticky sessions to route multiple requests through the **same exit IP**. Useful for multi-page scraping or sites that track IP consistency.
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--session` | Session ID (up to 255 chars) | *(none)* |
+| `--session-ttl` | TTL in minutes (1-240) | 15 |
+| `--session-mode` | `strict` or `flex` | `strict` |
+
+- **strict** (default): any proxy error invalidates the session and rotates to a new IP
+- **flex**: tolerates transient errors — session persists until too many consecutive failures
+- TTL is static — expires at creation time + TTL, not extended by subsequent requests
+- Changing `--country` or `--city` creates a different session
+
+---
+
+## Device-Type Targeting
+
+Route requests through specific device types using `--type`:
+
+| Value | Description |
+|-------|-------------|
+| `mobile` | Mobile device IPs |
+| `common` | Desktop/laptop IPs |
+| `tv` | Smart TV IPs |
+
+Can be combined with geo-targeting: `--type mobile --country US`
+
 ---
 
 ## FAQ & Troubleshooting
@@ -135,7 +193,10 @@ Geo-targeting flags are optional. They control which residential IP location to 
 > Python 3.8 or later.
 
 **Q: How do I get a new IP?**
-> Each invocation uses a different residential IP automatically. Just re-run the command.
+> Each invocation uses a different residential IP automatically, unless you use `--session`. Just re-run the command.
+
+**Q: How do I keep the same IP across requests?**
+> Use `--session myid` with the same session ID. The IP stays the same for 15 minutes by default (adjust with `--session-ttl`).
 
 **Error: "Missing Massive proxy credentials"**
 ```bash
@@ -145,13 +206,22 @@ echo 'MASSIVE_PROXY_PASSWORD="your-password"' >> ~/.openclaw/.env
 ```
 
 **Error: "Proxy authentication failed (407)"**
-> Your credentials are invalid. Check MASSIVE_PROXY_USERNAME and MASSIVE_PROXY_PASSWORD in your .env file. Verify them at [app.joinmassive.com](https://partners.joinmassive.com/login).
+> Your credentials are invalid. Check MASSIVE_PROXY_USERNAME and MASSIVE_PROXY_PASSWORD in your .env file. Verify them at [partners.joinmassive.com](https://partners.joinmassive.com/login).
 
 **Error: "Connection timed out"**
 > The proxy or target server didn't respond within the timeout. Retry the request.
 
 **Error: "SSL error"**
 > The target server has SSL issues. This is usually a problem with the target site, not the proxy.
+
+**Error: "Disallowed content (452)"**
+> The protocol, port, or content conflicts with Massive's content policy. Only ports 80/443 are allowed.
+
+**Error: "Service unavailable (503)"**
+> Geo-targeting constraints could not be met. Try relaxing location parameters (e.g. drop `--city` or `--zipcode`).
+
+**Error: "No upstream proxy available (521)"**
+> Insufficient proxy capacity for the specified location or ASN. Try a broader region.
 
 ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -57,6 +57,37 @@
  python3 scripts/fetch.py -u "https://httpbin.org/ip" | python3 -m json.tool > /dev/null && echo "VALID JSON"
  Expect: "VALID JSON" — confirms output is parseable.
 
+ 11. Sticky session — verify same IP across two requests
+
+ python3 scripts/fetch.py -u "https://httpbin.org/ip" --session test123
+ python3 scripts/fetch.py -u "https://httpbin.org/ip" --session test123
+ Expect: Both requests return the same IP in the body. The exit_node.ip should also match.
+
+ 12. Sticky session with TTL and flex mode
+
+ python3 scripts/fetch.py -u "https://httpbin.org/ip" --session flextest --session-ttl 5 --session-mode flex
+ Expect: status: 200, exit_node present. Session should persist through transient errors.
+
+ 13. Device-type targeting — mobile
+
+ python3 scripts/fetch.py -u "https://httpbin.org/ip" --type mobile --country US
+ Expect: status: 200, exit_node.country should be "US". IP should be from a mobile device.
+
+ 14. Device-type targeting — common (desktop)
+
+ python3 scripts/fetch.py -u "https://httpbin.org/ip" --type common
+ Expect: status: 200 with exit_node metadata.
+
+ 15. Exit node headers — verify exit_node in HTTPS response
+
+ python3 scripts/fetch.py -u "https://httpbin.org/ip" --country GB
+ Expect: exit_node object with ip, country ("GB"), timezone, and asn fields.
+
+ 16. Exit node headers — absent for HTTP
+
+ python3 scripts/fetch.py -u "http://httpbin.org/ip"
+ Expect: No exit_node field in the response (exit headers are HTTPS-only).
+
  ---
  What to Look For
 
@@ -67,3 +98,6 @@
  - JSON responses are pretty-printed in the body (test 7)
  - DNS errors produce clean JSON errors, not tracebacks (test 8)
  - HTTP 4xx/5xx are returned as responses, not errors (test 9)
+ - Sticky sessions return the same IP across requests (tests 11 and 12)
+ - Device-type targeting works with geo flags (tests 13 and 14)
+ - exit_node is present for HTTPS but absent for HTTP (tests 15 and 16)


### PR DESCRIPTION
This pull request introduces significant enhancements to ClawPod, expanding its capabilities with sticky sessions, device-type targeting, and improved proxy metadata handling. The documentation (`README.md`, `SKILL.md`, and `docs/testing.md`) and the main script (`scripts/fetch.py`) have been updated to reflect and support these new features, along with improved error handling and output.

**Major feature additions and improvements:**

*Sticky Sessions and Device-Type Targeting*
- Added support for sticky sessions via new flags (`--session`, `--session-ttl`, `--session-mode`) and device-type targeting with `--type` in both the CLI and documentation, allowing users to persist exit IPs across requests and specify the type of device for the exit node. [[1]](diffhunk://#diff-89dbe283d70d35a2a9b3a00189a1cc6db4940c122ddec5de1686273b3e76da27L83-R102) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R56-R59) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R80-R88) [[4]](diffhunk://#diff-0e95f5a3666031d6fac42bc6ca698b40b61648f4974c8ec355181ed4888c5c26R77-R85) [[5]](diffhunk://#diff-0e95f5a3666031d6fac42bc6ca698b40b61648f4974c8ec355181ed4888c5c26R119-R150) [[6]](diffhunk://#diff-0e95f5a3666031d6fac42bc6ca698b40b61648f4974c8ec355181ed4888c5c26R202-R205)

*Proxy Metadata and Output Enhancements*
- The response now includes an `exit_node` object containing IP, country, timezone, and ASN metadata for HTTPS requests, enabling users to verify geo-targeting and proxy characteristics. [[1]](diffhunk://#diff-89dbe283d70d35a2a9b3a00189a1cc6db4940c122ddec5de1686273b3e76da27R187-R228) [[2]](diffhunk://#diff-0e95f5a3666031d6fac42bc6ca698b40b61648f4974c8ec355181ed4888c5c26L113-R168) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L93-R117)
- Test documentation updated to verify sticky session behavior, device-type targeting, and presence/absence of `exit_node` metadata. [[1]](diffhunk://#diff-c22885d97fa21ad974a3f5f982d92b6f45edc251fd34bc14223492ebd7391245R60-R90) [[2]](diffhunk://#diff-c22885d97fa21ad974a3f5f982d92b6f45edc251fd34bc14223492ebd7391245R101-R103)

*Error Handling Improvements*
- Added explicit error handling and user-facing messages for new proxy errors: disallowed content (452), service unavailable (503), and no upstream proxy available (521). [[1]](diffhunk://#diff-89dbe283d70d35a2a9b3a00189a1cc6db4940c122ddec5de1686273b3e76da27R187-R228) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L148-R225)
- Clarified and updated error messages and troubleshooting steps in documentation.

*Documentation and Skill Metadata Updates*
- Expanded documentation in `README.md` and `SKILL.md` to explain new features, usage patterns, and caveats, including session modes, TTL, device types, and output format. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R148-R184) [[2]](diffhunk://#diff-0e95f5a3666031d6fac42bc6ca698b40b61648f4974c8ec355181ed4888c5c26R101-R106) [[3]](diffhunk://#diff-0e95f5a3666031d6fac42bc6ca698b40b61648f4974c8ec355181ed4888c5c26R119-R150)
- Updated skill metadata to declare tool command-dispatch and required environment variables.

*Miscellaneous and Maintenance*
- Fixed environment file loading path and updated proxy username construction logic for new parameters. [[1]](diffhunk://#diff-89dbe283d70d35a2a9b3a00189a1cc6db4940c122ddec5de1686273b3e76da27L40-R40) [[2]](diffhunk://#diff-89dbe283d70d35a2a9b3a00189a1cc6db4940c122ddec5de1686273b3e76da27L83-R102)
- Added Claude web fetch permission for documentation domain. (.claude/settings.local.json)

These changes make ClawPod a more powerful and flexible tool for residential proxy web fetching, with robust support for advanced session management and targeting scenarios.