### PR TITLE
Fix shell injection vulnerability in proxy URL encoding

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -120,14 +120,7 @@ https://myuser%3Fcountry%3DUS%26city%3DNew%20York:mypassword@network.joinmassive
 # No geo-targeting
 PROXY_URL="https://${MASSIVE_PROXY_USERNAME}:${MASSIVE_PROXY_PASSWORD}@network.joinmassive.com:65535"
 
-# With geo-targeting — encode the username
-ENCODED_USER=$(python3 -c "import urllib.parse; print(urllib.parse.quote('${MASSIVE_PROXY_USERNAME}?country=US&city=New York', safe=''))")
-PROXY_URL="https://${ENCODED_USER}:${MASSIVE_PROXY_PASSWORD}@network.joinmassive.com:65535"
-```
-
-Or encode manually:
-
-```bash
+# With geo-targeting — percent-encode the username inline
 ENCODED_USER="${MASSIVE_PROXY_USERNAME}%3Fcountry%3DUS%26city%3DNew%20York"
 PROXY_URL="https://${ENCODED_USER}:${MASSIVE_PROXY_PASSWORD}@network.joinmassive.com:65535"
 ```


### PR DESCRIPTION
Remove python3 -c command that interpolated MASSIVE_PROXY_USERNAME directly into a shell-executed Python string. Replace with inline percent-encoding which has no command execution and handles the same encoding cases (?=%3F, ==%3D, &=%26, space=%20).

Addresses VirusTotal security finding about potential arbitrary command execution via unsanitized environment variable.