### PR TITLE
feat: Add Google Search via Massive search endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # ClawPod
 
-Fetch and extract web page content through Massive's Unblocker REST API. Handles JavaScript rendering, anti-bot protection, CAPTCHAs, paywalls, and geo-restrictions server-side — returns rendered HTML that can be converted to clean markdown.
+Fetch web page content or search Google through Massive's Unblocker REST APIs. Handles JavaScript rendering, anti-bot protection, CAPTCHAs, paywalls, and geo-restrictions server-side — returns rendered HTML, clean markdown, or structured JSON.
 
 ---
 
 ## How It Works
 
-1. **You provide a URL** — the target page to fetch
+1. **You provide a URL or search query** — the target page to fetch or terms to search
 2. **Unblocker handles the rest** — JS rendering, CAPTCHA solving, retries, and anti-bot bypass all happen server-side
-3. **Content returned** — rendered HTML, optionally converted to markdown via `node-html-markdown`
+3. **Content returned** — rendered HTML, markdown via `node-html-markdown`, or structured JSON for search results
 
 ---
 
@@ -98,9 +98,39 @@ for url in "https://example.com/page1" "https://example.com/page2"; do
 done
 ```
 
+### Google Search
+
+```bash
+# Basic search (HTML results)
+curl -s -H "Authorization: Bearer $MASSIVE_UNBLOCKER_TOKEN" \
+  "https://unblocker.joinmassive.com/search?terms=foo+bar+baz"
+
+# Search with JSON output (structured results)
+curl -s -H "Authorization: Bearer $MASSIVE_UNBLOCKER_TOKEN" \
+  "https://unblocker.joinmassive.com/search?terms=foo+bar+baz&format=json"
+
+# 100 results per page, skip the first 20
+curl -s -H "Authorization: Bearer $MASSIVE_UNBLOCKER_TOKEN" \
+  "https://unblocker.joinmassive.com/search?terms=vpn+comparison&format=json&size=100&offset=20"
+
+# Multiple pages of results
+curl -s -H "Authorization: Bearer $MASSIVE_UNBLOCKER_TOKEN" \
+  "https://unblocker.joinmassive.com/search?terms=best+restaurants&format=json&serps=3"
+
+# Search in a specific language
+curl -s -H "Authorization: Bearer $MASSIVE_UNBLOCKER_TOKEN" \
+  "https://unblocker.joinmassive.com/search?terms=recetas+de+cocina&format=json&language=es"
+
+# Bypass cached results
+curl -s -H "Authorization: Bearer $MASSIVE_UNBLOCKER_TOKEN" \
+  "https://unblocker.joinmassive.com/search?terms=latest+news&format=json&expiration=0"
+```
+
 ---
 
 ## API Parameters
+
+### Browser (`/browser`)
 
 | Parameter | Values | Default | Description |
 |-----------|--------|---------|-------------|
@@ -110,6 +140,20 @@ done
 | `delay` | `0.1` to `10` (seconds) | none | Extra wait for dynamic content |
 | `device` | device name string | desktop | Device type for content |
 | `ip` | `residential`, `isp` | `residential` | ISP IPs for less detection |
+
+### Search (`/search`)
+
+| Parameter | Required | Values | Default | Description |
+|-----------|----------|--------|---------|-------------|
+| `terms` | yes | search query (`+` for spaces) | — | The search query |
+| `format` | no | `html`, `json` | `html` | Output format (`json` for structured data) |
+| `serps` | no | `1` to `10` | `1` | Number of results pages |
+| `size` | no | `0` to `100` | unset | Results per page |
+| `offset` | no | `0` to `100` | `0` | Number of initial results to skip |
+| `language` | no | name, ISO code, or Google code | unset | Search language |
+| `uule` | no | encoded location string | unset | Geo-target location |
+| `expiration` | no | `0` to N (days) | `1` | Cache age (`0` bypasses cache) |
+| `subaccount` | no | up to 255 chars | unset | Separate billing identifier |
 
 ---
 


### PR DESCRIPTION
## Summary
- Add Google Search capability using Massive's `/search` API endpoint alongside the existing `/browser` endpoint
- Support structured JSON and HTML output formats with pagination (`serps`, `size`, `offset`), language targeting, geo-targeting (`uule`), and cache controls
- Update both SKILL.md (skill definition with usage instructions, parameters, tips, rules) and README.md (examples, parameter reference)

## Test plan
- [ ] Verify search endpoint works with `format=json` and a sample query
- [ ] Confirm all documented parameters (`terms`, `serps`, `size`, `offset`, `language`, `uule`, `expiration`, `subaccount`) behave as expected
- [ ] Test that existing browser/fetch functionality is unaffected